### PR TITLE
Adds waitForAnimate checks

### DIFF
--- a/src/default-props.js
+++ b/src/default-props.js
@@ -31,7 +31,7 @@ var defaultProps = {
     useCSS: true,
     variableWidth: false,
     vertical: false,
-    // waitForAnimate: true,
+    waitForAnimate: false,
     afterChange: null,
     beforeChange: null,
     edgeEvent: null,

--- a/src/mixins/helpers.js
+++ b/src/mixins/helpers.js
@@ -79,6 +79,15 @@ var helpers = {
     var targetLeft, currentLeft;
     var callback;
 
+    if (this.props.waitForAnimate && this.state.animating) {
+      // Fix for NBC: We needed to reset the animating state here so that
+      // future calls to slideHandler() would work.
+      this.setState({
+        animating: false
+      });
+      return;
+    }
+
     if (this.props.fade) {
       currentSlide = this.state.currentSlide;
 


### PR DESCRIPTION
This prevents further slide transitions whilst there is an animation. It fixes draggable breaking on mobile for me.

cc @bettytran @flipactual @robcolburn 